### PR TITLE
Implement the literal square of a RationalRoot

### DIFF
--- a/src/RationalRoots.jl
+++ b/src/RationalRoots.jl
@@ -154,6 +154,9 @@ for op in (:*, :/, :\, ://)
         signedroot($op(signedsquare(x), signedsquare(y)))
 end
 
+# When squared, return Rational type:
+Base.literal_pow(::typeof(^), x::RationalRoot, ::Val{2}) = abs(x.signedsquare)
+
 Base.inv(x::RationalRoot) = signedroot(inv(signedsquare(x)))
 
 Base.one(x::RationalRoot) = one(typeof(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,7 @@ end
         @test iszero(zero(x))
         @test !isone(zero(x))
         @test zero(x) * x === zero(x)
+        @test x^2 === abs(a)
     end
 end
 


### PR DESCRIPTION
For x::RationalRoot, x^2 now returns abs(x.signedsquare).